### PR TITLE
Ver 3.2.0 アップデート

### DIFF
--- a/package/app/android/app/build.gradle
+++ b/package/app/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         // flavor関連

--- a/package/app/lib/ui/component/quiz_result_common/custom_confetti_widget.dart
+++ b/package/app/lib/ui/component/quiz_result_common/custom_confetti_widget.dart
@@ -1,12 +1,8 @@
-import 'dart:io';
 import 'dart:math';
 
 import 'package:confetti/confetti.dart';
 import 'package:flutter/material.dart';
 
-// ! iOS だと紙吹雪がうまく表示されない。
-// ! どうやらパッケージ側のバグっぽい。
-// ! 参考: https://github.com/funwithflutter/flutter_confetti/issues/55
 class CustomConfettiWidget extends StatefulWidget {
   const CustomConfettiWidget({
     super.key,
@@ -27,14 +23,12 @@ class _CustomConfettiWidgetState extends State<CustomConfettiWidget> {
   void initState() {
     super.initState();
 
-    // iOS の場合は紙吹雪を表示しない。
-    if (Platform.isIOS) {
-      return;
-    }
-
-    if (widget.isCorrect) {
-      confettiController.play();
-    }
+    // 画面が描画されたら紙吹雪を表示する。
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (widget.isCorrect) {
+        confettiController.play();
+      }
+    });
   }
 
   @override

--- a/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.g.dart
+++ b/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.g.dart
@@ -21,7 +21,7 @@ final hitterRepositoryProvider = AutoDisposeProvider<HitterRepository>.internal(
 );
 
 typedef HitterRepositoryRef = AutoDisposeProviderRef<HitterRepository>;
-String _$allHitterListHash() => r'de51752465a28fd063b24f0872dda8c1a55a831f';
+String _$allHitterListHash() => r'ce90e942f6d8620fd2222b08a24727e81ad0ef55';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #332 #338 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- targetSdkVerson を Android 34 に設定
- iOS 正解時に紙吹雪が表示されないバグを解消

## やらなかったこと

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- iPhone 15 Pro Max (Simulator) / iOS 17.2
- Pixel 7a (Emulator) / Android 33

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 問題なく動作すること

### 確認しなかった（できなかった）こと

- 

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - iOSデバイスでもコンフェッティアニメーションが表示されるようになりました。

- **改善**
  - AndroidアプリのターゲットSDKバージョンが34にアップグレードされ、新しい機能やセキュリティ強化を利用可能にしました。

- **バグ修正**
  - コンフェッティアニメーションのトリガーに関するロジックが改善され、正解の場合に全プラットフォームでアニメーションが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->