### PR TITLE
選手未入力で回答した際、エラーメッセージを表示する処理を実装

### DIFF
--- a/package/app/lib/ui/component/play_quiz_common/input_answer_text_field.dart
+++ b/package/app/lib/ui/component/play_quiz_common/input_answer_text_field.dart
@@ -8,6 +8,7 @@ class InputAnswerTextField extends StatelessWidget {
     required this.textEditingController,
     required this.onSearchHitter,
     required this.onSelectedHitter,
+    required this.showErrorText,
   });
 
   /// 回答入力用に使用する [TextEditingController].
@@ -23,21 +24,35 @@ class InputAnswerTextField extends StatelessWidget {
   /// 検索結果のリストの中から、選手を選択した際の処理。
   final void Function(Hitter value) onSelectedHitter;
 
+  /// 入力を促すエラーメッセージを表示するかどうか。
+  final bool showErrorText;
+
   final _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
-    return TextFieldSearch(
-      label: '選手名',
-      controller: textEditingController,
-      minStringLength: 0,
-      itemsInView: 5,
-      scrollbarDecoration: ScrollbarDecoration(
-        controller: _scrollController,
-        theme: const ScrollbarThemeData(),
-      ),
-      future: onSearchHitter,
-      getSelectedValue: onSelectedHitter,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextFieldSearch(
+          label: '選手名',
+          controller: textEditingController,
+          minStringLength: 0,
+          itemsInView: 5,
+          scrollbarDecoration: ScrollbarDecoration(
+            controller: _scrollController,
+            theme: const ScrollbarThemeData(),
+          ),
+          future: onSearchHitter,
+          getSelectedValue: onSelectedHitter,
+        ),
+        // エラーメッセージ
+        if (showErrorText)
+          Text(
+            '選手を入力して下さい...！',
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+      ],
     );
   }
 }

--- a/package/app/lib/ui/component/play_quiz_common/submit_answer_button.dart
+++ b/package/app/lib/ui/component/play_quiz_common/submit_answer_button.dart
@@ -24,7 +24,7 @@ class SubmitAnswerButton extends StatelessWidget {
     return MyButton(
       buttonName: 'submit_answer_button',
       buttonType: buttonType,
-      onPressed: hitter == null ? null : onTapSubmitAnswer,
+      onPressed: onTapSubmitAnswer,
       child: const Text('回答する'),
     );
   }

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
@@ -17,6 +17,9 @@ part 'play_daily_quiz_page_controller.g.dart';
 class PlayDailyQuizPageState with _$PlayDailyQuizPageState {
   const factory PlayDailyQuizPageState({
     required HitterQuizState quizState,
+
+    /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+    required bool showNotEnteredError,
   }) = _PlayDailyQuizPageState;
 }
 
@@ -34,7 +37,8 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
         .watch(hitterRepositoryProvider)
         .fetchInputDailyQuizState(dailyQuiz);
 
-    return PlayDailyQuizPageState(quizState: hitterQuizState);
+    return PlayDailyQuizPageState(
+        quizState: hitterQuizState, showNotEnteredError: false);
   }
 
   // * ---------------------- state.hitterQuiz の更新関連 ---------------------- * //
@@ -99,10 +103,11 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
 
   /// 今日の1問の回答を送信する際の処理。
   ///
-  /// [hitterName] が null の場合、[ArgumentError] をスローする。
+  /// [hitterName] が null の場合、入力を促すエラーを表示する。
   Future<void> onTapSubmitAnswer(String? hitterName) async {
     if (hitterName == null) {
-      throw ArgumentError.notNull('hitterName');
+      state = AsyncData(state.value!.copyWith(showNotEnteredError: true));
+      return;
     }
 
     // 間違えれる回数が上限に達している（最後の回答を送信している）場合、
@@ -151,6 +156,9 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
   void onSelectedHitter(Hitter value) {
     // 回答入力用のTextFieldのフォーカスを外す
     FocusManager.instance.primaryFocus?.unfocus();
+    // エラーメッセージを非表示にする。
+    state = AsyncData(state.value!.copyWith(showNotEnteredError: false));
+    
     _updateEnteredHitter(value);
   }
 

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
@@ -38,7 +38,9 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
         .fetchInputDailyQuizState(dailyQuiz);
 
     return PlayDailyQuizPageState(
-        quizState: hitterQuizState, showNotEnteredError: false);
+      quizState: hitterQuizState,
+      showNotEnteredError: false,
+    );
   }
 
   // * ---------------------- state.hitterQuiz の更新関連 ---------------------- * //
@@ -158,7 +160,7 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
     FocusManager.instance.primaryFocus?.unfocus();
     // エラーメッセージを非表示にする。
     state = AsyncData(state.value!.copyWith(showNotEnteredError: false));
-    
+
     _updateEnteredHitter(value);
   }
 

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.freezed.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.freezed.dart
@@ -18,6 +18,9 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$PlayDailyQuizPageState {
   HitterQuizState get quizState => throw _privateConstructorUsedError;
 
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  bool get showNotEnteredError => throw _privateConstructorUsedError;
+
   @JsonKey(ignore: true)
   $PlayDailyQuizPageStateCopyWith<PlayDailyQuizPageState> get copyWith =>
       throw _privateConstructorUsedError;
@@ -29,7 +32,7 @@ abstract class $PlayDailyQuizPageStateCopyWith<$Res> {
           $Res Function(PlayDailyQuizPageState) then) =
       _$PlayDailyQuizPageStateCopyWithImpl<$Res, PlayDailyQuizPageState>;
   @useResult
-  $Res call({HitterQuizState quizState});
+  $Res call({HitterQuizState quizState, bool showNotEnteredError});
 }
 
 /// @nodoc
@@ -47,12 +50,17 @@ class _$PlayDailyQuizPageStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? quizState = null,
+    Object? showNotEnteredError = null,
   }) {
     return _then(_value.copyWith(
       quizState: null == quizState
           ? _value.quizState
           : quizState // ignore: cast_nullable_to_non_nullable
               as HitterQuizState,
+      showNotEnteredError: null == showNotEnteredError
+          ? _value.showNotEnteredError
+          : showNotEnteredError // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -66,7 +74,7 @@ abstract class _$$PlayDailyQuizPageStateImplCopyWith<$Res>
       __$$PlayDailyQuizPageStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({HitterQuizState quizState});
+  $Res call({HitterQuizState quizState, bool showNotEnteredError});
 }
 
 /// @nodoc
@@ -83,12 +91,17 @@ class __$$PlayDailyQuizPageStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? quizState = null,
+    Object? showNotEnteredError = null,
   }) {
     return _then(_$PlayDailyQuizPageStateImpl(
       quizState: null == quizState
           ? _value.quizState
           : quizState // ignore: cast_nullable_to_non_nullable
               as HitterQuizState,
+      showNotEnteredError: null == showNotEnteredError
+          ? _value.showNotEnteredError
+          : showNotEnteredError // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -96,14 +109,19 @@ class __$$PlayDailyQuizPageStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$PlayDailyQuizPageStateImpl implements _PlayDailyQuizPageState {
-  const _$PlayDailyQuizPageStateImpl({required this.quizState});
+  const _$PlayDailyQuizPageStateImpl(
+      {required this.quizState, required this.showNotEnteredError});
 
   @override
   final HitterQuizState quizState;
 
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  @override
+  final bool showNotEnteredError;
+
   @override
   String toString() {
-    return 'PlayDailyQuizPageState(quizState: $quizState)';
+    return 'PlayDailyQuizPageState(quizState: $quizState, showNotEnteredError: $showNotEnteredError)';
   }
 
   @override
@@ -112,11 +130,13 @@ class _$PlayDailyQuizPageStateImpl implements _PlayDailyQuizPageState {
         (other.runtimeType == runtimeType &&
             other is _$PlayDailyQuizPageStateImpl &&
             (identical(other.quizState, quizState) ||
-                other.quizState == quizState));
+                other.quizState == quizState) &&
+            (identical(other.showNotEnteredError, showNotEnteredError) ||
+                other.showNotEnteredError == showNotEnteredError));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, quizState);
+  int get hashCode => Object.hash(runtimeType, quizState, showNotEnteredError);
 
   @JsonKey(ignore: true)
   @override
@@ -128,11 +148,15 @@ class _$PlayDailyQuizPageStateImpl implements _PlayDailyQuizPageState {
 
 abstract class _PlayDailyQuizPageState implements PlayDailyQuizPageState {
   const factory _PlayDailyQuizPageState(
-          {required final HitterQuizState quizState}) =
-      _$PlayDailyQuizPageStateImpl;
+      {required final HitterQuizState quizState,
+      required final bool showNotEnteredError}) = _$PlayDailyQuizPageStateImpl;
 
   @override
   HitterQuizState get quizState;
+  @override
+
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  bool get showNotEnteredError;
   @override
   @JsonKey(ignore: true)
   _$$PlayDailyQuizPageStateImplCopyWith<_$PlayDailyQuizPageStateImpl>

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.g.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.g.dart
@@ -7,7 +7,7 @@ part of 'play_daily_quiz_page_controller.dart';
 // **************************************************************************
 
 String _$playDailyQuizPageControllerHash() =>
-    r'0ea2a6b01632486f7ca303dda22453e5291e6893';
+    r'9cf668f350317896f2637265e540bbf4eb163b30';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
@@ -29,7 +29,9 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
   Future<PlayNormalQuizPageState> build() async {
     final hitterQuizState = await ref.watch(normalQuizStateProvider.future);
     return PlayNormalQuizPageState(
-        normalQuizState: hitterQuizState, showNotEnteredError: false);
+      normalQuizState: hitterQuizState,
+      showNotEnteredError: false,
+    );
   }
 
   // * ---------------------- state.hitterQuiz の更新関連 ---------------------- * //
@@ -143,7 +145,7 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
     FocusManager.instance.primaryFocus?.unfocus();
     // エラーメッセージを非表示にする。
     state = AsyncData(state.value!.copyWith(showNotEnteredError: false));
-    
+
     _updateEnteredHitter(hitter);
   }
 

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
@@ -17,6 +17,9 @@ part 'play_normal_quiz_page_controller.g.dart';
 class PlayNormalQuizPageState with _$PlayNormalQuizPageState {
   const factory PlayNormalQuizPageState({
     required HitterQuizState normalQuizState,
+
+    /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+    required bool showNotEnteredError,
   }) = _PlayNormalQuizPageState;
 }
 
@@ -25,7 +28,8 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
   @override
   Future<PlayNormalQuizPageState> build() async {
     final hitterQuizState = await ref.watch(normalQuizStateProvider.future);
-    return PlayNormalQuizPageState(normalQuizState: hitterQuizState);
+    return PlayNormalQuizPageState(
+        normalQuizState: hitterQuizState, showNotEnteredError: false);
   }
 
   // * ---------------------- state.hitterQuiz の更新関連 ---------------------- * //
@@ -90,10 +94,11 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
 
   /// 回答を送信する際の処理。
   ///
-  /// [hitterName] が null の場合、[ArgumentError] をスローする。
+  /// [hitterName] が null の場合、入力を促すエラーを表示する。
   Future<void> onSubmitAnswer(String? hitterName) async {
     if (hitterName == null) {
-      throw ArgumentError.notNull('hitterName');
+      state = AsyncData(state.value!.copyWith(showNotEnteredError: true));
+      return;
     }
 
     // interstitial 広告を作成する。
@@ -136,6 +141,9 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
 
   void onSelectedHitter(Hitter? hitter) {
     FocusManager.instance.primaryFocus?.unfocus();
+    // エラーメッセージを非表示にする。
+    state = AsyncData(state.value!.copyWith(showNotEnteredError: false));
+    
     _updateEnteredHitter(hitter);
   }
 

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.freezed.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.freezed.dart
@@ -18,6 +18,9 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$PlayNormalQuizPageState {
   HitterQuizState get normalQuizState => throw _privateConstructorUsedError;
 
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  bool get showNotEnteredError => throw _privateConstructorUsedError;
+
   @JsonKey(ignore: true)
   $PlayNormalQuizPageStateCopyWith<PlayNormalQuizPageState> get copyWith =>
       throw _privateConstructorUsedError;
@@ -29,7 +32,7 @@ abstract class $PlayNormalQuizPageStateCopyWith<$Res> {
           $Res Function(PlayNormalQuizPageState) then) =
       _$PlayNormalQuizPageStateCopyWithImpl<$Res, PlayNormalQuizPageState>;
   @useResult
-  $Res call({HitterQuizState normalQuizState});
+  $Res call({HitterQuizState normalQuizState, bool showNotEnteredError});
 }
 
 /// @nodoc
@@ -47,12 +50,17 @@ class _$PlayNormalQuizPageStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? normalQuizState = null,
+    Object? showNotEnteredError = null,
   }) {
     return _then(_value.copyWith(
       normalQuizState: null == normalQuizState
           ? _value.normalQuizState
           : normalQuizState // ignore: cast_nullable_to_non_nullable
               as HitterQuizState,
+      showNotEnteredError: null == showNotEnteredError
+          ? _value.showNotEnteredError
+          : showNotEnteredError // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -66,7 +74,7 @@ abstract class _$$PlayNormalQuizPageStateImplCopyWith<$Res>
       __$$PlayNormalQuizPageStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({HitterQuizState normalQuizState});
+  $Res call({HitterQuizState normalQuizState, bool showNotEnteredError});
 }
 
 /// @nodoc
@@ -83,12 +91,17 @@ class __$$PlayNormalQuizPageStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? normalQuizState = null,
+    Object? showNotEnteredError = null,
   }) {
     return _then(_$PlayNormalQuizPageStateImpl(
       normalQuizState: null == normalQuizState
           ? _value.normalQuizState
           : normalQuizState // ignore: cast_nullable_to_non_nullable
               as HitterQuizState,
+      showNotEnteredError: null == showNotEnteredError
+          ? _value.showNotEnteredError
+          : showNotEnteredError // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -96,14 +109,19 @@ class __$$PlayNormalQuizPageStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$PlayNormalQuizPageStateImpl implements _PlayNormalQuizPageState {
-  const _$PlayNormalQuizPageStateImpl({required this.normalQuizState});
+  const _$PlayNormalQuizPageStateImpl(
+      {required this.normalQuizState, required this.showNotEnteredError});
 
   @override
   final HitterQuizState normalQuizState;
 
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  @override
+  final bool showNotEnteredError;
+
   @override
   String toString() {
-    return 'PlayNormalQuizPageState(normalQuizState: $normalQuizState)';
+    return 'PlayNormalQuizPageState(normalQuizState: $normalQuizState, showNotEnteredError: $showNotEnteredError)';
   }
 
   @override
@@ -112,11 +130,14 @@ class _$PlayNormalQuizPageStateImpl implements _PlayNormalQuizPageState {
         (other.runtimeType == runtimeType &&
             other is _$PlayNormalQuizPageStateImpl &&
             (identical(other.normalQuizState, normalQuizState) ||
-                other.normalQuizState == normalQuizState));
+                other.normalQuizState == normalQuizState) &&
+            (identical(other.showNotEnteredError, showNotEnteredError) ||
+                other.showNotEnteredError == showNotEnteredError));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, normalQuizState);
+  int get hashCode =>
+      Object.hash(runtimeType, normalQuizState, showNotEnteredError);
 
   @JsonKey(ignore: true)
   @override
@@ -128,11 +149,15 @@ class _$PlayNormalQuizPageStateImpl implements _PlayNormalQuizPageState {
 
 abstract class _PlayNormalQuizPageState implements PlayNormalQuizPageState {
   const factory _PlayNormalQuizPageState(
-          {required final HitterQuizState normalQuizState}) =
-      _$PlayNormalQuizPageStateImpl;
+      {required final HitterQuizState normalQuizState,
+      required final bool showNotEnteredError}) = _$PlayNormalQuizPageStateImpl;
 
   @override
   HitterQuizState get normalQuizState;
+  @override
+
+  /// 回答が未入力の旨のエラーメッセージを表示するかどうか。
+  bool get showNotEnteredError;
   @override
   @JsonKey(ignore: true)
   _$$PlayNormalQuizPageStateImplCopyWith<_$PlayNormalQuizPageStateImpl>

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.g.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.g.dart
@@ -7,7 +7,7 @@ part of 'play_normal_quiz_page_controller.dart';
 // **************************************************************************
 
 String _$playNormalQuizPageControllerHash() =>
-    r'7a741471aa90b45c925fcea59b0252d1ec56eee3';
+    r'0411c1eca9c3eb79db8d7a509c5be0e863556c8f';
 
 /// See also [PlayNormalQuizPageController].
 @ProviderFor(PlayNormalQuizPageController)

--- a/package/app/lib/ui/page/play_daily_quiz_page.dart
+++ b/package/app/lib/ui/page/play_daily_quiz_page.dart
@@ -73,6 +73,7 @@ class _PlayDailyQuizPageState extends ConsumerState<PlayDailyQuizPage> {
                         onSearchHitter: () async => controller
                             .onSearchHitter(_textEditingController.text),
                         onSelectedHitter: controller.onSelectedHitter,
+                        showErrorText: pageState.showNotEnteredError,
                       ),
                       const SizedBox(height: 16),
                       QuizEventButtons(

--- a/package/app/lib/ui/page/play_normal_quiz_page.dart
+++ b/package/app/lib/ui/page/play_normal_quiz_page.dart
@@ -58,6 +58,7 @@ class _PlayNormalQuizPageState extends ConsumerState<PlayNormalQuizPage> {
                       onSearchHitter: () => controller
                           .onSearchHitter(_textEditingController.text),
                       onSelectedHitter: controller.onSelectedHitter,
+                      showErrorText: pageState.showNotEnteredError,
                     ),
                     const SizedBox(height: 16),
                     QuizEventButtons(


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #341 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- 選手未入力で回答した際、エラーメッセージを表示する処理を実装

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- iPhone 15 (Simulator) / iOS 17.5

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- 問題なく動作すること

### 確認しなかった（できなかった）こと

- 

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザー入力に基づいてエラーメッセージを表示する新しい機能を追加し、ユーザーエクスペリエンスを向上。
	- クイズページにおけるエラー処理を改善し、入力エラー時のフィードバックを即座に提供。
	- `QuizEventButtons`ウィジェットに新しいパラメータを追加し、ユーザーの入力不足を通知。

- **バグ修正**
	- `hitterName`がnullの場合でもボタンが常に有効になるように修正。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->